### PR TITLE
Fix #1475 (`--global` installs to `~/.local`)

### DIFF
--- a/changelog.d/1475.bugfix.md
+++ b/changelog.d/1475.bugfix.md
@@ -1,0 +1,1 @@
+Stop `pipx install --global` from installing files in `~/.local`.

--- a/changelog.d/1475.feature.md
+++ b/changelog.d/1475.feature.md
@@ -1,0 +1,1 @@
+List `PIPX_GLOBAL_[HOME|BIN_DIR|MAN_DIR]` in `pipx environment`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -148,23 +148,27 @@ Example configuration for use of the code linter [yapf](https://github.com/googl
 
 The default binary location for pipx-installed apps is `~/.local/bin`. This can be overridden with the environment
 variable `PIPX_BIN_DIR`. The default manual page location for pipx-installed apps is `~/.local/share/man`. This can be
-overridden with the environment variable `PIPX_MAN_DIR`.
+overridden with the environment variable `PIPX_MAN_DIR`. If the `--global` option is used, the default locations are
+`/usr/local/bin` and `/usr/local/share/man` respectively and can be overridden with `PIPX_GLOBAL_BIN_DIR` and
+`PIPX_GLOBAL_MAN_DIR`.
 
 pipx's default virtual environment location is typically `~/.local/share/pipx` on Linux/Unix, `~/.local/pipx` on MacOS
 and `~\pipx` on Windows. For compatibility reasons, if `~/.local/pipx` on Linux, `%USERPROFILE%\AppData\Local\pipx` or
 `~\.local\pipx` on Windows or `~/Library/Application Support/pipx` on MacOS exists, it will be used as the default location instead.
-This can be overridden with the `PIPX_HOME` environment variable.
+This can be overridden with the `PIPX_HOME` environment variable. If the `--global` option is used, the default location is always
+`/opt/pipx` and can be overridden with `PIPX_GLOBAL_HOME`.
 
 In case one of these fallback locations exist, we recommend either manually moving the pipx files to the new default location
 (see the [Moving your pipx installation](installation.md#moving-your-pipx-installation) section of the docs), or setting the
 `PIPX_HOME` environment variable (discarding files existing in the fallback location).
 
-As an example, you can install global apps accessible by all users on your system with the following command (on MacOS,
+As an example, you can install global apps accessible by all users on your system with either of the following commands (on MacOS,
 Linux, and Windows WSL):
 
 ```
-sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man pipx install PACKAGE
-# Example: $ sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man pipx install cowsay
+sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man pipx install <PACKAGE>
+# or shorter (with pipx>=1.5.0)
+sudo pipx --global install <PACKAGE>
 ```
 
 > [!NOTE]

--- a/src/pipx/commands/environment.py
+++ b/src/pipx/commands/environment.py
@@ -11,8 +11,11 @@ def environment(value: str) -> ExitCode:
     """Print a list of environment variables and paths used by pipx"""
     environment_variables = [
         "PIPX_HOME",
+        "PIPX_GLOBAL_HOME",
         "PIPX_BIN_DIR",
+        "PIPX_GLOBAL_BIN_DIR",
         "PIPX_MAN_DIR",
+        "PIPX_GLOBAL_MAN_DIR",
         "PIPX_SHARED_LIBS",
         "PIPX_DEFAULT_PYTHON",
         "PIPX_FETCH_MISSING_PYTHON",

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -85,8 +85,11 @@ PIPX_DESCRIPTION += pipx_wrap(
     """
     optional environment variables:
       PIPX_HOME              Overrides default pipx location. Virtual Environments will be installed to $PIPX_HOME/venvs.
+      PIPX_GLOBAL_HOME       Used instead of PIPX_HOME when the `--global` option is given.
       PIPX_BIN_DIR           Overrides location of app installations. Apps are symlinked or copied here.
+      PIPX_GLOBAL_BIN_DIR    Used instead of PIPX_BIN_DIR when the `--global` option is given.
       PIPX_MAN_DIR           Overrides location of manual pages installations. Manual pages are symlinked or copied here.
+      PIPX_GLOBAL_MAN_DIR    Used instead of PIPX_MAN_DIR when the `--global` option is given.
       PIPX_DEFAULT_PYTHON    Overrides default python used for commands.
       USE_EMOJI              Overrides emoji behavior. Default value varies based on platform.
       PIPX_HOME_ALLOW_SPACE  Overrides default warning on spaces in the home path
@@ -122,15 +125,24 @@ INSTALL_DESCRIPTION = textwrap.dedent(
 
     The PACKAGE_SPEC argument is passed directly to `pip install`.
 
-    The default virtual environment location is {paths.DEFAULT_PIPX_HOME}
-    and can be overridden by setting the environment variable `PIPX_HOME`
-    (Virtual Environments will be installed to `$PIPX_HOME/venvs`).
+    Virtual Environments will be installed to `$PIPX_HOME/venvs`.
+    The default pipx home location is {paths.DEFAULT_PIPX_HOME} and can
+    be overridden by setting the environment variable `PIPX_HOME`.
+    If the `--global` option is used, the default pipx home location
+    instead is {paths.DEFAULT_PIPX_GLOBAL_HOME} and can be overridden
+    by setting the environment variable `PIPX_GLOBAL_HOME`.
 
     The default app location is {paths.DEFAULT_PIPX_BIN_DIR} and can be
     overridden by setting the environment variable `PIPX_BIN_DIR`.
+    If the `--global` option is used, the default app location instead
+    is {paths.DEFAULT_PIPX_GLOBAL_BIN_DIR} and can be overridden by
+    setting the environment variable `PIPX_GLOBAL_BIN_DIR`.
 
     The default manual pages location is {paths.DEFAULT_PIPX_MAN_DIR} and
     can be overridden by setting the environment variable `PIPX_MAN_DIR`.
+    If the `--global` option is used, the default manual pages location
+    instead is {paths.DEFAULT_PIPX_GLOBAL_MAN_DIR} and can be overridden
+    by setting the environment variable `PIPX_GLOBAL_MAN_DIR`.
 
     The default python executable used to install a package is
     {DOC_DEFAULT_PYTHON} and can be overridden

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -907,8 +907,10 @@ def _add_environment(subparsers: argparse._SubParsersAction, shared_parser: argp
             variables and platform specific default values.
 
             Available variables:
-            PIPX_HOME, PIPX_BIN_DIR, PIPX_MAN_DIR, PIPX_SHARED_LIBS, PIPX_LOCAL_VENVS,
-            PIPX_LOG_DIR, PIPX_TRASH_DIR, PIPX_VENV_CACHEDIR, PIPX_DEFAULT_PYTHON, USE_EMOJI, PIPX_HOME_ALLOW_SPACE
+            PIPX_HOME, PIPX_GLOBAL_HOME, PIPX_BIN_DIR, PIPX_GLOBAL_BIN_DIR,
+            PIPX_MAN_DIR, PIPX_GLOBAL_MAN_DIR, PIPX_SHARED_LIBS, PIPX_LOCAL_VENVS,
+            PIPX_LOG_DIR, PIPX_TRASH_DIR, PIPX_VENV_CACHEDIR, PIPX_DEFAULT_PYTHON,
+            USE_EMOJI, PIPX_HOME_ALLOW_SPACE
             """
         ),
         parents=[shared_parser],

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -200,8 +200,7 @@ def package_is_path(package: str):
 
 def run_pipx_command(args: argparse.Namespace, subparsers: Dict[str, argparse.ArgumentParser]) -> ExitCode:  # noqa: C901
     verbose = args.verbose if "verbose" in args else False
-    if not constants.WINDOWS and args.is_global:
-        paths.ctx.make_global()
+
     pip_args = get_pip_args(vars(args))
     venv_args = get_venv_args(vars(args))
 
@@ -1086,6 +1085,9 @@ def setup(args: argparse.Namespace) -> None:
     if "version" in args and args.version:
         print_version()
         sys.exit(0)
+
+    if not constants.WINDOWS and args.is_global:
+        paths.ctx.make_global()
 
     verbose = args.verbose - args.quiet
 

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -38,8 +38,11 @@ def get_expanded_environ(env_name: str) -> Optional[Path]:
 
 class _PathContext:
     _base_home: Optional[Union[Path, str]] = get_expanded_environ("PIPX_HOME")
+    _default_home: Union[Path, str] = DEFAULT_PIPX_HOME
     _base_bin: Optional[Union[Path, str]] = get_expanded_environ("PIPX_BIN_DIR")
+    _default_bin: Union[Path, str] = DEFAULT_PIPX_BIN_DIR
     _base_man: Optional[Union[Path, str]] = get_expanded_environ("PIPX_MAN_DIR")
+    _default_man: Union[Path, str] = DEFAULT_PIPX_MAN_DIR
     _base_shared_libs: Optional[Union[Path, str]] = get_expanded_environ("PIPX_SHARED_LIBS")
     _fallback_homes: List[Path] = FALLBACK_PIPX_HOMES
     _fallback_home: Optional[Path] = next(iter([fallback for fallback in _fallback_homes if fallback.exists()]), None)
@@ -70,11 +73,11 @@ class _PathContext:
 
     @property
     def bin_dir(self) -> Path:
-        return Path(self._base_bin or DEFAULT_PIPX_BIN_DIR).resolve()
+        return Path(self._base_bin or self._default_bin).resolve()
 
     @property
     def man_dir(self) -> Path:
-        return Path(self._base_man or DEFAULT_PIPX_MAN_DIR).resolve()
+        return Path(self._base_man or self._default_man).resolve()
 
     @property
     def home(self) -> Path:
@@ -83,7 +86,7 @@ class _PathContext:
         elif self._fallback_home:
             home = self._fallback_home
         else:
-            home = Path(DEFAULT_PIPX_HOME)
+            home = Path(self._default_home)
         return home.resolve()
 
     @property
@@ -92,15 +95,27 @@ class _PathContext:
 
     def make_local(self) -> None:
         self._base_home = get_expanded_environ("PIPX_HOME")
+        self._default_home = DEFAULT_PIPX_HOME
         self._base_bin = get_expanded_environ("PIPX_BIN_DIR")
+        self._default_bin = DEFAULT_PIPX_BIN_DIR
         self._base_man = get_expanded_environ("PIPX_MAN_DIR")
+        self._default_man = DEFAULT_PIPX_MAN_DIR
+        self._base_shared_libs = get_expanded_environ("PIPX_SHARED_LIBS")
+        self._fallback_homes = FALLBACK_PIPX_HOMES
+        self._fallback_home = next(iter([fallback for fallback in self._fallback_homes if fallback.exists()]), None)
         self._home_exists = self._base_home is not None or any(fallback.exists() for fallback in self._fallback_homes)
 
     def make_global(self) -> None:
-        self._base_home = get_expanded_environ("PIPX_GLOBAL_HOME") or DEFAULT_PIPX_GLOBAL_HOME
-        self._base_bin = get_expanded_environ("PIPX_GLOBAL_BIN_DIR") or DEFAULT_PIPX_GLOBAL_BIN_DIR
-        self._base_man = get_expanded_environ("PIPX_GLOBAL_MAN_DIR") or DEFAULT_PIPX_GLOBAL_MAN_DIR
-        self._home_exists = self._base_home is not None or any(fallback.exists() for fallback in self._fallback_homes)
+        self._base_home = get_expanded_environ("PIPX_GLOBAL_HOME")
+        self._default_home = DEFAULT_PIPX_GLOBAL_HOME
+        self._base_bin = get_expanded_environ("PIPX_GLOBAL_BIN_DIR")
+        self._default_bin = DEFAULT_PIPX_GLOBAL_BIN_DIR
+        self._base_man = get_expanded_environ("PIPX_GLOBAL_MAN_DIR")
+        self._default_man = DEFAULT_PIPX_GLOBAL_MAN_DIR
+        self._base_shared_libs = None
+        self._fallback_homes = []
+        self._fallback_home = None
+        self._home_exists = self._base_home is not None
 
     @property
     def standalone_python_cachedir(self) -> Path:

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import time
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Dict
 
 from pipx import paths
 from pipx.animate import animate
@@ -23,21 +23,39 @@ SHARED_LIBS_MAX_AGE_SEC = datetime.timedelta(days=30).total_seconds()
 
 class _SharedLibs:
     def __init__(self) -> None:
-        self.root = paths.ctx.shared_libs
-        self.bin_path, self.python_path, self.man_path = get_venv_paths(self.root)
-        self.pip_path = self.bin_path / ("pip" if not WINDOWS else "pip.exe")
-        # i.e. bin_path is ~/.local/share/pipx/shared/bin
-        # i.e. python_path is ~/.local/share/pipx/shared/python
-        self._site_packages: Optional[Path] = None
+        self._site_packages: Dict[Path, Path] = {}
         self.has_been_updated_this_run = False
         self.has_been_logged_this_run = False
 
     @property
-    def site_packages(self) -> Path:
-        if self._site_packages is None:
-            self._site_packages = get_site_packages(self.python_path)
+    def root(self) -> Path:
+        return paths.ctx.shared_libs
 
-        return self._site_packages
+    @property
+    def bin_path(self) -> Path:
+        bin_path, _, _ = get_venv_paths(self.root)
+        return bin_path
+
+    @property
+    def python_path(self) -> Path:
+        _, python_path, _ = get_venv_paths(self.root)
+        return python_path
+
+    @property
+    def man_path(self) -> Path:
+        _, _, man_path = get_venv_paths(self.root)
+        return man_path
+
+    @property
+    def pip_path(self) -> Path:
+        return self.bin_path / ("pip" if not WINDOWS else "pip.exe")
+
+    @property
+    def site_packages(self) -> Path:
+        if self.python_path not in self._site_packages:
+            self._site_packages[self.python_path] = get_site_packages(self.python_path)
+
+        return self._site_packages[self.python_path]
 
     def create(self, pip_args: List[str], verbose: bool = False) -> None:
         if not self.is_valid:
@@ -46,8 +64,6 @@ class _SharedLibs:
                     [DEFAULT_PYTHON, "-m", "venv", "--clear", self.root], run_dir=str(self.root)
                 )
             subprocess_post_check(create_process)
-            # Recompute these paths, as they might resolve differently now, see comment in get_venv_paths
-            self.bin_path, self.python_path, self.man_path = get_venv_paths(self.root)
 
             # ignore installed packages to ensure no unexpected patches from the OS vendor
             # are used

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import time
 from pathlib import Path
-from typing import List, Dict
+from typing import Dict, List
 
 from pipx import paths
 from pipx.animate import animate


### PR DESCRIPTION
:information_source: _Does not fix https://github.com/pypa/pipx/issues/1443 (pipx install --global order broken), which is a completely different problem with the --global flag._

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

- [x] Changed setup/initialization order of pipx.paths and pipx.shared_libs to correctly account for the global flag.
- [x] Added `PIPX_GLOBAL_[HOME|BIN_DIR|MAN_DIR]` the output of `pipx environment`.
- [x] Extended and updated documentation related to `--global`.

## Test plan

Tested by running

```sh
$ docker run -it --rm python:3 bash
$$ pip install git+https://github.com/viscruocco/pipx.git@fix-global-path-handling
$$ pipx install --global cowsay
$$ which cowsay
/usr/local/bin/cowsay
$$ ls /opt/pipx/
py  shared  venvs
$$ ls ~/.local/state/pipx/
log       # --> pipx logs are still in ~/.local
$$ ls ~/.local/
state     # --> nothing else from pipx is in ~/.local
```
